### PR TITLE
Edit CMakefiles.txt in Driver to Fix Boost Dependency on Kinetic

### DIFF
--- a/lslidar_c16_driver/CMakeLists.txt
+++ b/lslidar_c16_driver/CMakeLists.txt
@@ -21,7 +21,7 @@ catkin_package(
     roscpp diagnostic_updater nodelet
     lslidar_c16_msgs
   DEPENDS
-    boost
+    Boost
 )
 
 include_directories(


### PR DESCRIPTION
when I use the catkin build command it's shown the warning that the Boost Dependency is not found.
so I found this topic in answer ros that fix that warning :)

![image](https://user-images.githubusercontent.com/5821937/68830296-d936ae80-06dd-11ea-8022-42cae6f39fc1.png)


https://answers.ros.org/question/251005/cmake-warning-on-boost_include_dirs/
